### PR TITLE
Adding searchBar integration for the page customContent

### DIFF
--- a/src/imports/controls/SearchBar11.qml
+++ b/src/imports/controls/SearchBar11.qml
@@ -45,6 +45,8 @@ Item {
 
     property var searchResults: ListModel {}
 
+    property var customContentIntegration: false
+
     signal search(string query)
 
     function open() {
@@ -62,7 +64,8 @@ Item {
         searchResults.clear();
         searchTextField.focus = false;
     }
-
+    
+    anchors.fill: customContentIntegration? parent: null
     anchors {left: parent.left; right: parent.right; top: parent.top}
     height: 64
 
@@ -72,7 +75,7 @@ Item {
             id: openSearchButton
 
             anchors.right: parent.right
-            anchors.top: parent.top
+            anchors.top: customContentIntegration? null: parent.top
             anchors.margins: 8
 
             icon.source: FluidControls.Utils.iconUrl("action/search")
@@ -91,6 +94,7 @@ Item {
             }
             FluidControls.Card {
                 id: searchCard
+                anchors.fill: customContentIntegration? parent: null                
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.margins: Units.smallSpacing


### PR DESCRIPTION
There is a problem when including the searchBar inside the menuBar (Page/customContents)
I added a new variable customContentIntegration (false by default), when used and changed to true the searchBar will fit inside the menu bar (customContent variable in fluidControls.Page)

The following screenshots shows the layouting problems without the changes of this PR:
![Untitled2](https://user-images.githubusercontent.com/15939806/103038778-98ab9480-456f-11eb-9446-ed600874c598.png)
![Untitled](https://user-images.githubusercontent.com/15939806/103038783-99dcc180-456f-11eb-80cc-3f21b397e420.png)



